### PR TITLE
Lush up diffusion reverb

### DIFF
--- a/.guides/NOTES.md
+++ b/.guides/NOTES.md
@@ -7,6 +7,8 @@
 - If a track is marked finished, the mixer is allowed to drain its remaining buffered samples without blocking on it.
 - Mixing while a non-finished track buffer is empty causes dropouts and misalignment; avoid advancing the playhead in that case.
 - Reverb/effects tail is mixed only after track buffers are empty, so keep the effects buffer draining logic intact.
+- Diffusion reverb implementation notes and tuning guidance live in `.guides/diffusion_reverb.md`.
+- Diffusion reverb now uses per-channel decorrelated lanes; avoid reverting to a single shared interleaved delay network, which increases metallic ringing.
 - File-based playback preserves alignment by advancing non-active windows with underlay silence.
   The silence is now represented with virtual zero-fill segments (metadata) instead of materialized zero sample buffers.
 

--- a/.guides/diffusion_reverb.md
+++ b/.guides/diffusion_reverb.md
@@ -1,0 +1,89 @@
+# Diffusion Reverb (Algorithmic) Notes
+
+This guide documents the current `DiffusionReverb` implementation in
+`proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs`.
+
+## Current Topology (2026-02-24)
+
+The implementation is a Schroeder-inspired algorithmic reverb with extra
+diffusion and per-channel decorrelation:
+
+1. Pre-delay
+2. Input diffusion (`3` series allpass filters)
+3. Late reverb tank (`8` parallel lowpass-feedback comb filters)
+4. Output diffusion (`3` series allpass filters)
+5. Gentle wet-output lowpass tone shaping
+
+Important implementation detail:
+- Reverb is processed as one independent lane per channel (e.g. separate L/R
+  lanes for stereo), with small channel-specific delay offsets to reduce
+  correlation and metallic stereo ringing.
+
+## Why It Sounds Less Metallic Than The Older Version
+
+Compared to the earlier version (4 combs + 2 allpasses, shared interleaved
+network), the current version improves tail quality by:
+
+- Increasing modal density (8 combs instead of 4)
+- Adding input diffusion before the comb bank (smears transients earlier)
+- Adding output diffusion after the comb bank (smooths late tail)
+- Separating channels into decorrelated lanes (prevents cross-channel coupling)
+- Applying a light post-wet lowpass (reduces harsh high-frequency ringing)
+
+## User-Facing Controls
+
+The public settings remain:
+
+- `pre_delay_ms`
+- `room_size_ms`
+- `decay`
+- `damping`
+- `diffusion`
+- effect `mix`
+
+These are mapped internally into the denser topology; no schema change was
+required for the update.
+
+## Practical Tuning (Warmer / Deeper / Lusher)
+
+Use these heuristics when dialing in the effect:
+
+- Increase `room_size_ms` before pushing `decay`
+  - Larger delay spacing usually reads as “deeper room” more naturally than
+    simply increasing feedback.
+- Raise `damping` to reduce metallic brightness
+  - Typical warm range: `0.45..0.65`
+  - Lower values sound brighter and more reflective.
+- Keep `diffusion` moderately high, not maxed
+  - Typical lush range: `0.65..0.80`
+  - Too low sounds grainy; too high can blur attacks and produce a cloudy tail.
+- Use `decay` conservatively
+  - Typical musical range: `0.70..0.85`
+  - Very high values can still emphasize resonant modes on tonal/percussive material.
+- Set `mix` based on insert vs send usage
+  - Insert: lower mix to preserve articulation
+  - Send/aux: higher mix is usually appropriate
+
+## Example Starting Points
+
+### Warm Room / Plate-like
+
+- `pre_delay_ms`: `8..16`
+- `room_size_ms`: `40..60`
+- `decay`: `0.72..0.80`
+- `damping`: `0.48..0.62`
+- `diffusion`: `0.68..0.78`
+
+### Deep Ambient Tail
+
+- `pre_delay_ms`: `16..28`
+- `room_size_ms`: `55..85`
+- `decay`: `0.80..0.88`
+- `damping`: `0.50..0.70`
+- `diffusion`: `0.72..0.82`
+
+## Future Improvements (If Needed)
+
+If the tail still sounds too static on exposed sources, the next high-value
+upgrade is subtle delay modulation (usually on diffuser and/or comb lengths).
+That is the standard step toward a more “lush” chorused algorithmic reverb.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,5 @@
 
 ## Persistent Notes
 - See `.guides/NOTES.md` for playback alignment constraints that should always be preserved.
+- In this repository, "knowledge base" always refers to the `knowledge-base/` directory.
+- Keep `knowledge-base/` documents up to date when `proteus-lib` behavior, algorithms, or effect implementations change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "proteus-lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dasp_ring_buffer",
  "log",

--- a/knowledge-base/algorithm-schroeder-moorer-reverb.md
+++ b/knowledge-base/algorithm-schroeder-moorer-reverb.md
@@ -16,6 +16,20 @@ y_a[n] = -a\,x[n] + x[n-M] + a\,y_a[n-M]
 
 Typical networks sum several comb filters in parallel and follow them with one or more all-pass stages in series.
 
+## Proteus Context
+
+Proteus's `DiffusionReverb` uses a Schroeder/Moorer-inspired structure with
+additional diffusion and tonal smoothing:
+
+- input pre-delay
+- input all-pass diffusion stages
+- parallel low-pass-feedback comb tank
+- output all-pass diffusion stages
+- light wet-output low-pass tone shaping
+
+Proteus also runs one decorrelated reverb lane per channel (small channel-specific
+delay offsets) to reduce metallic ringing and stereo correlation artifacts.
+
 ## Variable Key
 - $`x[n]`$: input sample
 - $`y_c[n]`$: comb output

--- a/knowledge-base/audio-effects-diffusion-reverb.md
+++ b/knowledge-base/audio-effects-diffusion-reverb.md
@@ -1,52 +1,78 @@
 # Audio Effect: Diffusion Reverb
 
 ## What it is
-A **diffusion‑based reverb** that smears transients using short, dense delay networks to create a smooth, early‑reflection style reverb.
+A **Schroeder-inspired algorithmic reverb** with extra diffusion stages, low-pass damped comb feedback, and per-channel decorrelated lanes for a smoother, less metallic tail.
 
 ## How it behaves (plain language)
-- The input passes through a network of short delays and all‑pass filters.
-- This spreads the energy in time, reducing sharp transients.
-- The result is a **cloudy, smooth** reverb tail without long echoes.
+- The input gets a short pre-delay, then is diffused before it reaches the reverb tank.
+- Multiple comb filters build the decay tail while damping reduces high-frequency build-up.
+- Additional output diffusion and a gentle wet low-pass soften the late tail.
+- Stereo (or multi-channel) input is processed with separate decorrelated lanes, which reduces metallic stereo ringing.
 
 ## How it works (step‑by‑step)
 1. Convert `pre_delay_ms` and `room_size_ms` into sample counts.
-2. Build a tuning profile: 1 pre‑delay line, 4 parallel comb filters, and 2 series all‑pass filters.
-3. For each incoming sample:
-4. Apply the pre‑delay line.
-5. Feed the delayed sample into the 4 comb filters in parallel.
-6. Each comb filter uses low‑pass damping in its feedback loop, then feeds back by `decay`.
-7. Average the comb outputs and pass the result through two all‑pass filters in series.
-8. Mix wet with dry using `mix` (`output = dry*(1‑mix) + wet*mix`).
-9. If draining, feed zeros through the network long enough to emit the tail.
+2. Build a tuning profile per channel lane: 1 pre-delay line, 3 input all-pass diffusers, 8 parallel comb filters, and 3 output all-pass diffusers.
+3. Apply small channel-specific delay offsets so each lane is decorrelated.
+4. For each incoming sample, route each interleaved channel sample into its matching reverb lane.
+5. Apply the lane pre-delay.
+6. Pass the signal through 3 input all-pass diffusers (transient smearing / early density).
+7. Feed the diffused sample into 8 comb filters in parallel.
+8. Each comb filter uses low-pass damping in its feedback loop, then feeds back by `decay`.
+9. Average the comb outputs and pass the result through 3 output all-pass diffusers.
+10. Apply a gentle one-pole low-pass to the wet signal to soften high-frequency ringing.
+11. Mix wet with dry using `mix` (`output = dry*(1‑mix) + wet*mix`).
+12. If draining, feed zeros through the lanes long enough to emit the tail.
 
 ## Signal Flow (simplified)
 
 ```
-Input ─► Diffusion Network (short delays / all‑pass) ─► Wet
-   └───────────────────────────────────────────────► Dry
-                          └────────── Mix ─────────► Output
+Input ─► Pre-delay ─► Input Diffusion ─► Comb Tank ─► Output Diffusion ─► Wet Tone LPF ─► Wet
+   └───────────────────────────────────────────────────────────────────────────────────────► Dry
+                                                     └──────────── Mix ───────────────────► Output
 ```
 
 ## Controls (conceptual)
 
 | Control | What it changes | Audible effect |
 | --- | --- | --- |
-| `dry_wet` | Blend between dry and wet | More/less diffusion |
+| `dry_wet` / `wet_dry` (`mix`) | Blend between dry and wet | More/less reverb presence |
 | `enabled` | Bypass when false | Dry only |
+| `pre_delay_ms` | Gap before reverb starts | More clarity / perceived depth |
+| `room_size_ms` | Internal delay scaling | Bigger/deeper space impression |
+| `decay` | Comb feedback amount | Longer/shorter tail |
+| `damping` | HF damping in feedback | Darker/warmer vs brighter/metallic |
+| `diffusion` | Diffuser feedback | Smoother/denser vs grainier |
 
 ## Technical
-The design is a **comb + all-pass diffusion network**: parallel comb filters build modal density, then serial all-pass sections smear phase/transients to reduce discrete echo perception. This is the canonical architecture of **Schroeder/Moorer algorithmic reverb** and closely related to widely used lightweight designs such as Freeverb-style structures.
+The design is a **multi-stage comb + all-pass diffusion network**: input all-pass diffusion spreads transients before the comb tank, 8 parallel low-pass-feedback combs build the late decay, then output all-pass diffusion and a light wet low-pass smooth the tail.
+
+The implementation is still in the Schroeder/Moorer family, but uses a denser topology than a minimal comb+all-pass network. In Proteus specifically, channel lanes are decorrelated (small delay-length offsets per channel) to avoid the metallic artifacts that can occur when interleaved multi-channel samples share one scalar delay network.
 
 Its research precedent is that dense, decorrelated reflections can be synthesized without convolution by carefully tuned delay lengths, feedback, and damping. The low-pass damping in feedback loops follows the same practical model used in many algorithmic reverbs to emulate high-frequency air/surface absorption over time.
 
+## Tuning for a warmer / deeper / lusher sound
+
+- Increase `room_size_ms` before pushing `decay`
+  - Bigger spacing often sounds deeper and less “ringy” than just increasing feedback.
+- Raise `damping` for warmth (`~0.45..0.65`)
+  - This is the main control for reducing metallic brightness.
+- Keep `diffusion` moderately high (`~0.65..0.80`)
+  - Higher density smooths the tail, but maxing it can blur attacks.
+- Use `decay` conservatively (`~0.70..0.85`) for general musical use
+  - Very high values can still emphasize resonances on tonal/percussive sources.
+- Adjust `mix` by routing style
+  - Insert: lower `mix`
+  - Send/aux: higher `mix`
+
 ## Typical use
 - Smoothing harsh transients
-- Creating a “room‑like” or “ambience” style reverb
+- Creating a warm room / ambient algorithmic reverb
+- A lightweight alternative to convolution when CPU budget matters
 
 ## Key properties
 
 | Property | Value |
 | --- | --- |
 | Latency | Low‑to‑medium |
-| CPU cost | Low‑to‑medium |
-| Tail character | Smooth, short, dense |
+| CPU cost | Low‑to‑medium (higher than simple delay reverb; much lower than convolution) |
+| Tail character | Smooth, denser, darker, less metallic than the earlier sparse topology |

--- a/proteus-lib/Cargo.toml
+++ b/proteus-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proteus-lib"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Adam Thomas Howard <adamthomashoward@gmail.com>"]
 license-file = "../LICENSE"

--- a/proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs
+++ b/proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs
@@ -9,6 +9,12 @@
 //! Each channel keeps an independent reverb lane (with small decorrelated
 //! delay offsets) to avoid cross-channel ringing from processing interleaved
 //! samples through one shared delay network.
+//!
+//! # Tuning Notes
+//! - For a warmer/deeper tail, increase `room_size_ms` first, then `decay`.
+//! - Raise `damping` (`~0.45..0.65`) to reduce metallic high-frequency ringing.
+//! - Keep `diffusion` moderately high (`~0.65..0.80`) for density without excessive smear.
+//! - Use lower `mix` for insert use on full mixes; higher `mix` works better on sends/auxes.
 
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -33,26 +39,38 @@ const OUTPUT_ALLPASS_TUNING_MULTIPLIERS: [f32; 3] = [0.28, 0.41, 0.57];
 #[serde(default)]
 pub struct DiffusionReverbSettings {
     /// Pre-delay time in milliseconds.
+    ///
+    /// Increases the gap between the dry signal and the reverb onset, which
+    /// improves clarity and perceived depth.
     pub pre_delay_ms: u64,
-    /// Base delay time in milliseconds that scales the comb filters.
+    /// Base delay time in milliseconds that scales the internal diffuser/comb timings.
+    ///
+    /// Larger values generally produce a deeper, larger-sounding space.
     pub room_size_ms: u64,
-    /// Feedback amount for the comb filters. Higher values mean longer decay.
+    /// Feedback amount for the comb filters.
+    ///
+    /// Higher values increase reverb time. Excessively high values can make the
+    /// tail ring or feel static, especially on bright sources.
     pub decay: f32,
-    /// Lowpass damping applied inside the comb feedback path.
+    /// Lowpass damping applied inside each comb feedback path.
+    ///
+    /// Higher values darken the tail and reduce metallic brightness.
     pub damping: f32,
-    /// Feedback amount for the allpass diffusers. Higher values increase density.
+    /// Feedback amount for the allpass diffusers.
+    ///
+    /// Higher values increase density and smoothness, but can blur transients.
     pub diffusion: f32,
 }
 
 impl DiffusionReverbSettings {
-    /// Create diffusion reverb settings with basic validation.
+    /// Create diffusion reverb settings with validation and clamping.
     ///
     /// # Arguments
     /// - `pre_delay_ms`: Pre-delay time in milliseconds.
-    /// - `room_size_ms`: Base delay for the comb filters in milliseconds.
+    /// - `room_size_ms`: Base delay for the internal timing network in milliseconds.
     /// - `decay`: Comb feedback gain in the range `[0.0, 1.0)`.
-    /// - `damping`: Lowpass damping factor in the range `[0.0, 1.0)`.
-    /// - `diffusion`: Allpass feedback gain in the range `[0.0, 1.0)`.
+    /// - `damping`: Comb feedback lowpass damping in the range `[0.0, 1.0)`.
+    /// - `diffusion`: Diffuser allpass feedback gain in the range `[0.0, 1.0)`.
     ///
     /// # Returns
     /// The validated settings.
@@ -97,7 +115,10 @@ impl Default for DiffusionReverbSettings {
     }
 }
 
-/// Diffusion reverb effect (pre-delay + combs + allpass diffusion).
+/// Diffusion reverb effect with a Schroeder-inspired, multi-stage topology.
+///
+/// Internally this maintains one decorrelated reverb lane per output channel to
+/// avoid left/right cross-coupled ringing when processing interleaved buffers.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct DiffusionReverbEffect {
@@ -132,7 +153,7 @@ impl std::fmt::Debug for DiffusionReverbEffect {
 }
 
 impl DiffusionReverbEffect {
-    /// Create a new diffusion reverb effect.
+    /// Create a new diffusion reverb effect with default settings.
     ///
     /// # Arguments
     /// - `mix`: Wet/dry mix in the range `[0.0, 1.0]`.
@@ -151,10 +172,14 @@ impl DiffusionReverbEffect {
     /// # Arguments
     /// - `samples`: Interleaved input samples.
     /// - `context`: Environment details (sample rate, channels, etc.).
-    /// - `drain`: When true, flush buffered tail data.
+    /// - `drain`: When true and `samples` is empty, flush buffered tail data.
     ///
     /// # Returns
     /// Processed interleaved samples.
+    ///
+    /// # Notes
+    /// - Input is treated as interleaved frames using `context.channels`.
+    /// - If the buffer length is not frame-aligned, trailing samples are passed through unchanged.
     pub fn process(&mut self, samples: &[f32], context: &EffectContext, drain: bool) -> Vec<f32> {
         self.ensure_state(context);
         if !self.enabled || self.mix <= 0.0 {
@@ -189,7 +214,7 @@ impl DiffusionReverbEffect {
         output
     }
 
-    /// Reset any internal state buffers.
+    /// Reset all internal delay/filter buffers and drop the current state.
     ///
     /// # Returns
     /// Nothing.
@@ -201,6 +226,9 @@ impl DiffusionReverbEffect {
     }
 
     /// Mutable access to the diffusion reverb settings.
+    ///
+    /// Changing timing-related fields (`pre_delay_ms`, `room_size_ms`) will cause
+    /// the internal state to be rebuilt on the next call to [`Self::process`].
     pub fn settings_mut(&mut self) -> &mut DiffusionReverbSettings {
         &mut self.settings
     }
@@ -222,6 +250,10 @@ impl DiffusionReverbEffect {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Derived delay lengths for the internal reverb topology.
+///
+/// This is computed from user settings and sample rate, then optionally
+/// decorrelated per channel so each lane rings differently.
 struct Tuning {
     pre_delay_samples: usize,
     comb_samples: [usize; 8],
@@ -231,6 +263,7 @@ struct Tuning {
 }
 
 impl Tuning {
+    /// Build tuning values from pre-delay and room-size sample counts.
     fn new(pre_delay_samples: usize, room_size_samples: usize) -> Self {
         let comb_samples = COMB_TUNING_MULTIPLIERS
             .map(|multiplier| (room_size_samples as f32 * multiplier).round() as usize);
@@ -256,6 +289,10 @@ impl Tuning {
         }
     }
 
+    /// Apply small channel-dependent offsets to reduce stereo correlation.
+    ///
+    /// This preserves the general room scale while changing exact modal spacing
+    /// across channels.
     fn decorrelated(self, channel_index: usize) -> Self {
         if channel_index == 0 {
             return self;
@@ -302,6 +339,10 @@ impl Tuning {
 }
 
 #[derive(Clone)]
+/// Runtime state for the diffusion reverb effect.
+///
+/// Holds one [`ReverbLane`] per channel and routes interleaved frames into the
+/// matching lane.
 struct DiffusionReverbState {
     tuning: Tuning,
     channels: usize,
@@ -309,6 +350,7 @@ struct DiffusionReverbState {
 }
 
 impl DiffusionReverbState {
+    /// Create a new state instance for the current tuning and channel count.
     fn new(tuning: Tuning, channels: usize) -> Self {
         info!("Using Diffusion Reverb!");
         let lanes = (0..channels)
@@ -321,12 +363,17 @@ impl DiffusionReverbState {
         }
     }
 
+    /// Reset all channel lanes.
     fn reset(&mut self) {
         for lane in &mut self.lanes {
             lane.reset();
         }
     }
 
+    /// Process interleaved samples into the provided output buffer.
+    ///
+    /// The `diffusion` control is mapped to separate input/output diffuser
+    /// strengths so early smearing and late-tail smoothing can be balanced.
     fn process_samples(
         &mut self,
         samples: &[f32],
@@ -360,6 +407,7 @@ impl DiffusionReverbState {
         }
     }
 
+    /// Drain the buffered reverb tail by feeding silence through all lanes.
     fn drain_tail(&mut self, decay: f32, damping: f32, diffusion: f32) -> Vec<f32> {
         let input_diffusion = (0.25 + diffusion * 0.35).clamp(0.1, 0.7);
         let output_diffusion = (0.2 + diffusion * 0.45).clamp(0.1, 0.8);
@@ -377,6 +425,10 @@ impl DiffusionReverbState {
 }
 
 #[derive(Clone)]
+/// One complete mono reverb lane used by a single output channel.
+///
+/// Layout: pre-delay -> input allpass diffusion -> comb bank ->
+/// output allpass diffusion -> wet tone lowpass.
 struct ReverbLane {
     pre_delay: DelayLine,
     input_allpass: [AllpassFilter; 3],
@@ -386,6 +438,7 @@ struct ReverbLane {
 }
 
 impl ReverbLane {
+    /// Build a lane using a channel-specific tuning table.
     fn new(tuning: Tuning) -> Self {
         Self {
             pre_delay: DelayLine::new(tuning.pre_delay_samples),
@@ -413,6 +466,7 @@ impl ReverbLane {
         }
     }
 
+    /// Reset the lane and all internal filters/delays.
     fn reset(&mut self) {
         self.pre_delay.reset();
         for allpass in &mut self.input_allpass {
@@ -427,6 +481,11 @@ impl ReverbLane {
         self.wet_tone.reset();
     }
 
+    /// Process one mono sample through the lane.
+    ///
+    /// `input_diffusion` and `output_diffusion` are derived from the user-facing
+    /// diffusion control and intentionally use different ranges to keep attacks
+    /// clear while still smoothing the late tail.
     fn process_sample(
         &mut self,
         input: f32,
@@ -457,12 +516,14 @@ impl ReverbLane {
 }
 
 #[derive(Clone)]
+/// Fixed-length circular delay line.
 struct DelayLine {
     buffer: Vec<f32>,
     index: usize,
 }
 
 impl DelayLine {
+    /// Create a delay line with at least one sample of storage.
     fn new(len: usize) -> Self {
         Self {
             buffer: vec![0.0; len.max(1)],
@@ -470,11 +531,13 @@ impl DelayLine {
         }
     }
 
+    /// Clear the delay buffer and rewind the write index.
     fn reset(&mut self) {
         self.buffer.fill(0.0);
         self.index = 0;
     }
 
+    /// Push one sample and return the delayed sample at the current tap.
     fn process(&mut self, input: f32) -> f32 {
         let output = self.buffer[self.index];
         self.buffer[self.index] = input;
@@ -487,6 +550,9 @@ impl DelayLine {
 }
 
 #[derive(Clone)]
+/// Lowpass-feedback comb filter used to build the late reverb decay.
+///
+/// The internal lowpass reduces high-frequency build-up in the feedback loop.
 struct CombFilter {
     buffer: Vec<f32>,
     index: usize,
@@ -494,6 +560,7 @@ struct CombFilter {
 }
 
 impl CombFilter {
+    /// Create a comb filter with a fixed delay length.
     fn new(len: usize) -> Self {
         Self {
             buffer: vec![0.0; len.max(1)],
@@ -502,12 +569,19 @@ impl CombFilter {
         }
     }
 
+    /// Clear delay and lowpass state.
     fn reset(&mut self) {
         self.buffer.fill(0.0);
         self.index = 0;
         self.lowpass = 0.0;
     }
 
+    /// Process one sample through the comb filter.
+    ///
+    /// # Arguments
+    /// - `input`: Dry/diffused input into the comb.
+    /// - `feedback`: Feedback gain controlling decay time.
+    /// - `damping`: One-pole lowpass smoothing in the feedback path.
     fn process(&mut self, input: f32, feedback: f32, damping: f32) -> f32 {
         let delayed = self.buffer[self.index];
         self.lowpass = delayed * (1.0 - damping) + self.lowpass * damping;
@@ -522,12 +596,14 @@ impl CombFilter {
 }
 
 #[derive(Clone)]
+/// Standard feedback allpass diffuser.
 struct AllpassFilter {
     buffer: Vec<f32>,
     index: usize,
 }
 
 impl AllpassFilter {
+    /// Create an allpass filter with a fixed delay length.
     fn new(len: usize) -> Self {
         Self {
             buffer: vec![0.0; len.max(1)],
@@ -535,11 +611,13 @@ impl AllpassFilter {
         }
     }
 
+    /// Clear the delay buffer and rewind the read/write position.
     fn reset(&mut self) {
         self.buffer.fill(0.0);
         self.index = 0;
     }
 
+    /// Process one sample through the allpass diffuser.
     fn process(&mut self, input: f32, feedback: f32) -> f32 {
         let delayed = self.buffer[self.index];
         let output = delayed - feedback * input;
@@ -553,21 +631,30 @@ impl AllpassFilter {
 }
 
 #[derive(Clone, Default)]
+/// One-pole lowpass used to slightly darken the wet output tail.
 struct OnePoleLowpass {
     state: f32,
 }
 
 impl OnePoleLowpass {
+    /// Reset the filter state.
     fn reset(&mut self) {
         self.state = 0.0;
     }
 
+    /// Process one sample with the provided smoothing coefficient.
+    ///
+    /// `smoothing` near `1.0` produces a darker/slower response.
     fn process(&mut self, input: f32, smoothing: f32) -> f32 {
         self.state = input * (1.0 - smoothing) + self.state * smoothing;
         self.state
     }
 }
 
+/// Convert milliseconds to per-channel sample counts.
+///
+/// The returned value represents samples for a single channel lane (not the
+/// total number of interleaved scalar values).
 fn delay_samples(sample_rate: u32, duration_ms: u64) -> usize {
     if duration_ms == 0 {
         return 0;

--- a/proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs
+++ b/proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs
@@ -1,12 +1,14 @@
 //! Algorithmic reverb with smooth diffusion.
 //!
-//! This reverb follows a classic Schroeder-style layout:
+//! This reverb uses a Schroeder-inspired layout with extra diffusion stages:
 //! 1) A pre-delay to separate the direct sound from the reverb onset.
-//! 2) A set of parallel lowpass feedback comb filters to build decay.
-//! 3) A pair of series allpass filters to smooth the diffusion.
+//! 2) A short series of input allpass diffusers to spread transients.
+//! 3) A bank of parallel lowpass feedback comb filters to build decay.
+//! 4) A short set of output allpass diffusers plus tone shaping for a softer tail.
 //!
-//! The comb filters create the overall decay envelope while the allpass
-//! stages smear transients so the tail sounds dense instead of grainy.
+//! Each channel keeps an independent reverb lane (with small decorrelated
+//! delay offsets) to avoid cross-channel ringing from processing interleaved
+//! samples through one shared delay network.
 
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -22,8 +24,9 @@ const MAX_DECAY: f32 = 0.98;
 const MAX_DAMPING: f32 = 0.99;
 const MAX_DIFFUSION: f32 = 0.9;
 
-const COMB_TUNING_MULTIPLIERS: [f32; 4] = [1.0, 1.33, 1.58, 1.91];
-const ALLPASS_TUNING_MULTIPLIERS: [f32; 2] = [0.28, 0.52];
+const COMB_TUNING_MULTIPLIERS: [f32; 8] = [1.0, 1.09, 1.2, 1.33, 1.47, 1.63, 1.82, 2.03];
+const INPUT_ALLPASS_TUNING_MULTIPLIERS: [f32; 3] = [0.07, 0.11, 0.17];
+const OUTPUT_ALLPASS_TUNING_MULTIPLIERS: [f32; 3] = [0.28, 0.41, 0.57];
 
 /// Serialized configuration for the diffusion reverb.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,24 +206,17 @@ impl DiffusionReverbEffect {
     }
 
     fn ensure_state(&mut self, context: &EffectContext) {
-        let pre_delay_samples = delay_samples(
-            context.sample_rate,
-            context.channels,
-            self.settings.pre_delay_ms,
-        );
-        let room_size_samples = delay_samples(
-            context.sample_rate,
-            context.channels,
-            self.settings.room_size_ms,
-        );
+        let pre_delay_samples = delay_samples(context.sample_rate, self.settings.pre_delay_ms);
+        let room_size_samples = delay_samples(context.sample_rate, self.settings.room_size_ms);
         let tuning = Tuning::new(pre_delay_samples, room_size_samples);
+        let channels = context.channels.max(1);
         let needs_reset = self
             .state
             .as_ref()
-            .map(|state| state.tuning != tuning)
+            .map(|state| state.tuning != tuning || state.channels != channels)
             .unwrap_or(true);
         if needs_reset {
-            self.state = Some(DiffusionReverbState::new(tuning));
+            self.state = Some(DiffusionReverbState::new(tuning, channels));
         }
     }
 }
@@ -228,8 +224,9 @@ impl DiffusionReverbEffect {
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct Tuning {
     pre_delay_samples: usize,
-    comb_samples: [usize; 4],
-    allpass_samples: [usize; 2],
+    comb_samples: [usize; 8],
+    input_allpass_samples: [usize; 3],
+    output_allpass_samples: [usize; 3],
     max_delay: usize,
 }
 
@@ -237,12 +234,15 @@ impl Tuning {
     fn new(pre_delay_samples: usize, room_size_samples: usize) -> Self {
         let comb_samples = COMB_TUNING_MULTIPLIERS
             .map(|multiplier| (room_size_samples as f32 * multiplier).round() as usize);
-        let allpass_samples = ALLPASS_TUNING_MULTIPLIERS
+        let input_allpass_samples = INPUT_ALLPASS_TUNING_MULTIPLIERS
+            .map(|multiplier| (room_size_samples as f32 * multiplier).round() as usize);
+        let output_allpass_samples = OUTPUT_ALLPASS_TUNING_MULTIPLIERS
             .map(|multiplier| (room_size_samples as f32 * multiplier).round() as usize);
         let max_delay = comb_samples
             .iter()
             .copied()
-            .chain(allpass_samples.iter().copied())
+            .chain(input_allpass_samples.iter().copied())
+            .chain(output_allpass_samples.iter().copied())
             .chain([pre_delay_samples])
             .max()
             .unwrap_or(1)
@@ -250,46 +250,80 @@ impl Tuning {
         Self {
             pre_delay_samples: pre_delay_samples.max(1),
             comb_samples: comb_samples.map(|value| value.max(1)),
-            allpass_samples: allpass_samples.map(|value| value.max(1)),
+            input_allpass_samples: input_allpass_samples.map(|value| value.max(1)),
+            output_allpass_samples: output_allpass_samples.map(|value| value.max(1)),
             max_delay,
         }
+    }
+
+    fn decorrelated(self, channel_index: usize) -> Self {
+        if channel_index == 0 {
+            return self;
+        }
+        let channel_step = channel_index as usize;
+        let mut tuned = self;
+        tuned.pre_delay_samples = tuned.pre_delay_samples.saturating_add(channel_step * 3);
+        tuned.comb_samples = tuned
+            .comb_samples
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| len.saturating_add(channel_step * (5 + i * 2)))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap_or(tuned.comb_samples);
+        tuned.input_allpass_samples = tuned
+            .input_allpass_samples
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| len.saturating_add(channel_step * (2 + i)))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap_or(tuned.input_allpass_samples);
+        tuned.output_allpass_samples = tuned
+            .output_allpass_samples
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| len.saturating_add(channel_step * (3 + i)))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap_or(tuned.output_allpass_samples);
+        tuned.max_delay = tuned
+            .comb_samples
+            .iter()
+            .copied()
+            .chain(tuned.input_allpass_samples.iter().copied())
+            .chain(tuned.output_allpass_samples.iter().copied())
+            .chain([tuned.pre_delay_samples])
+            .max()
+            .unwrap_or(1)
+            .max(1);
+        tuned
     }
 }
 
 #[derive(Clone)]
 struct DiffusionReverbState {
     tuning: Tuning,
-    pre_delay: DelayLine,
-    combs: [CombFilter; 4],
-    allpass: [AllpassFilter; 2],
+    channels: usize,
+    lanes: Vec<ReverbLane>,
 }
 
 impl DiffusionReverbState {
-    fn new(tuning: Tuning) -> Self {
+    fn new(tuning: Tuning, channels: usize) -> Self {
         info!("Using Diffusion Reverb!");
+        let lanes = (0..channels)
+            .map(|channel| ReverbLane::new(tuning.decorrelated(channel)))
+            .collect();
         Self {
             tuning,
-            pre_delay: DelayLine::new(tuning.pre_delay_samples),
-            combs: [
-                CombFilter::new(tuning.comb_samples[0]),
-                CombFilter::new(tuning.comb_samples[1]),
-                CombFilter::new(tuning.comb_samples[2]),
-                CombFilter::new(tuning.comb_samples[3]),
-            ],
-            allpass: [
-                AllpassFilter::new(tuning.allpass_samples[0]),
-                AllpassFilter::new(tuning.allpass_samples[1]),
-            ],
+            channels,
+            lanes,
         }
     }
 
     fn reset(&mut self) {
-        self.pre_delay.reset();
-        for comb in &mut self.combs {
-            comb.reset();
-        }
-        for allpass in &mut self.allpass {
-            allpass.reset();
+        for lane in &mut self.lanes {
+            lane.reset();
         }
     }
 
@@ -302,37 +336,123 @@ impl DiffusionReverbState {
         diffusion: f32,
         out: &mut Vec<f32>,
     ) {
-        for &sample in samples {
-            let delayed = self.pre_delay.process(sample);
-            let mut comb_sum = 0.0;
-            for comb in &mut self.combs {
-                comb_sum += comb.process(delayed, decay, damping);
+        let channels = self.channels.max(1);
+        let input_diffusion = (0.25 + diffusion * 0.35).clamp(0.1, 0.7);
+        let output_diffusion = (0.2 + diffusion * 0.45).clamp(0.1, 0.8);
+
+        for frame in samples.chunks_exact(channels) {
+            for (channel, &sample) in frame.iter().enumerate() {
+                let wet = self.lanes[channel].process_sample(
+                    sample,
+                    decay,
+                    damping,
+                    input_diffusion,
+                    output_diffusion,
+                );
+                out.push(sample * (1.0 - mix) + wet * mix);
             }
-            let mut wet = comb_sum * 0.25;
-            for allpass in &mut self.allpass {
-                wet = allpass.process(wet, diffusion);
-            }
-            let output = sample * (1.0 - mix) + wet * mix;
-            out.push(output);
+        }
+
+        let remainder = samples.len() % channels;
+        if remainder != 0 {
+            let start = samples.len() - remainder;
+            out.extend_from_slice(&samples[start..]);
         }
     }
 
     fn drain_tail(&mut self, decay: f32, damping: f32, diffusion: f32) -> Vec<f32> {
-        let tail_samples = self.tuning.max_delay.saturating_mul(4).max(1);
-        let mut out = Vec::with_capacity(tail_samples);
-        for _ in 0..tail_samples {
-            let delayed = self.pre_delay.process(0.0);
-            let mut comb_sum = 0.0;
-            for comb in &mut self.combs {
-                comb_sum += comb.process(delayed, decay, damping);
+        let input_diffusion = (0.25 + diffusion * 0.35).clamp(0.1, 0.7);
+        let output_diffusion = (0.2 + diffusion * 0.45).clamp(0.1, 0.8);
+        let tail_frames = self.tuning.max_delay.saturating_mul(8).max(1);
+        let mut out = Vec::with_capacity(tail_frames.saturating_mul(self.channels));
+        for _ in 0..tail_frames {
+            for lane in &mut self.lanes {
+                let wet =
+                    lane.process_sample(0.0, decay, damping, input_diffusion, output_diffusion);
+                out.push(wet);
             }
-            let mut wet = comb_sum * 0.25;
-            for allpass in &mut self.allpass {
-                wet = allpass.process(wet, diffusion);
-            }
-            out.push(wet);
         }
         out
+    }
+}
+
+#[derive(Clone)]
+struct ReverbLane {
+    pre_delay: DelayLine,
+    input_allpass: [AllpassFilter; 3],
+    combs: [CombFilter; 8],
+    output_allpass: [AllpassFilter; 3],
+    wet_tone: OnePoleLowpass,
+}
+
+impl ReverbLane {
+    fn new(tuning: Tuning) -> Self {
+        Self {
+            pre_delay: DelayLine::new(tuning.pre_delay_samples),
+            input_allpass: [
+                AllpassFilter::new(tuning.input_allpass_samples[0]),
+                AllpassFilter::new(tuning.input_allpass_samples[1]),
+                AllpassFilter::new(tuning.input_allpass_samples[2]),
+            ],
+            combs: [
+                CombFilter::new(tuning.comb_samples[0]),
+                CombFilter::new(tuning.comb_samples[1]),
+                CombFilter::new(tuning.comb_samples[2]),
+                CombFilter::new(tuning.comb_samples[3]),
+                CombFilter::new(tuning.comb_samples[4]),
+                CombFilter::new(tuning.comb_samples[5]),
+                CombFilter::new(tuning.comb_samples[6]),
+                CombFilter::new(tuning.comb_samples[7]),
+            ],
+            output_allpass: [
+                AllpassFilter::new(tuning.output_allpass_samples[0]),
+                AllpassFilter::new(tuning.output_allpass_samples[1]),
+                AllpassFilter::new(tuning.output_allpass_samples[2]),
+            ],
+            wet_tone: OnePoleLowpass::default(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.pre_delay.reset();
+        for allpass in &mut self.input_allpass {
+            allpass.reset();
+        }
+        for comb in &mut self.combs {
+            comb.reset();
+        }
+        for allpass in &mut self.output_allpass {
+            allpass.reset();
+        }
+        self.wet_tone.reset();
+    }
+
+    fn process_sample(
+        &mut self,
+        input: f32,
+        decay: f32,
+        damping: f32,
+        input_diffusion: f32,
+        output_diffusion: f32,
+    ) -> f32 {
+        let mut x = self.pre_delay.process(input);
+        for allpass in &mut self.input_allpass {
+            x = allpass.process(x, input_diffusion);
+        }
+
+        let mut comb_sum = 0.0;
+        for comb in &mut self.combs {
+            comb_sum += comb.process(x, decay, damping);
+        }
+
+        let mut wet = comb_sum / self.combs.len() as f32;
+        for allpass in &mut self.output_allpass {
+            wet = allpass.process(wet, output_diffusion);
+        }
+
+        // Soften high-frequency ringing in the late tail.
+        let tone_smoothing = (0.55 + damping * 0.35).clamp(0.2, 0.95);
+        self.wet_tone.process(wet, tone_smoothing)
     }
 }
 
@@ -432,11 +552,27 @@ impl AllpassFilter {
     }
 }
 
-fn delay_samples(sample_rate: u32, channels: usize, duration_ms: u64) -> usize {
+#[derive(Clone, Default)]
+struct OnePoleLowpass {
+    state: f32,
+}
+
+impl OnePoleLowpass {
+    fn reset(&mut self) {
+        self.state = 0.0;
+    }
+
+    fn process(&mut self, input: f32, smoothing: f32) -> f32 {
+        self.state = input * (1.0 - smoothing) + self.state * smoothing;
+        self.state
+    }
+}
+
+fn delay_samples(sample_rate: u32, duration_ms: u64) -> usize {
     if duration_ms == 0 {
         return 0;
     }
     let ns = duration_ms.saturating_mul(1_000_000);
-    let samples = ns.saturating_mul(sample_rate as u64) / 1_000_000_000 * channels as u64;
+    let samples = ns.saturating_mul(sample_rate as u64) / 1_000_000_000;
     samples as usize
 }


### PR DESCRIPTION
## What changed

  - 8 parallel combs instead of 4 for denser modal distribution: proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:27
  - Added 3 input allpass diffusers before the comb bank and 3 output allpasses after it: proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:28, proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:29
  - Per-channel reverb lanes (with small decorrelated delay offsets) instead of one shared network over interleaved samples: proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:304, proteus-lib/src/
    dsp/effects/diffusion_reverb/mod.rs:311
  - Gentle post-tail one-pole lowpass to soften high-frequency ringing: proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:453, proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:555
  - Delay tuning now uses per-channel sample counts (not interleaved scalar counts), which is the correct basis for a per-channel reverb lane: proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:208,
    proteus-lib/src/dsp/effects/diffusion_reverb/mod.rs:571

## Why this sounds warmer/lusher

  - More combs + more diffusion stages reduce isolated ringing modes.
  - Input diffusion smears transients before they hit the feedback tank.
  - Output diffusion smooths the late tail.
  - Per-channel decorrelation avoids left/right feeding the same resonant path.
  - The wet-tail lowpass trims the “metal” edge without killing depth.